### PR TITLE
basic-setup.sh: fix dns resolve; apt cache update; traceroute install

### DIFF
--- a/basic-setup.sh
+++ b/basic-setup.sh
@@ -5,10 +5,15 @@ hostname=$(hostname)
 # fix DNS resolving in some cases
 echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
+# update apt cache
+apt-get update -y
+
 # install gobgp
 cp /tmp/gobgpd.conf /etc
-apt-get update -y
 apt-get install gobgpd -y
+
+# install traceroute
+apt-get install traceroute -y
 
 whoami
 printenv

--- a/basic-setup.sh
+++ b/basic-setup.sh
@@ -2,9 +2,13 @@
 
 hostname=$(hostname)
 
+# fix DNS resolving in some cases
+echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
 # install gobgp
 cp /tmp/gobgpd.conf /etc
-apt-get install gobgpd
+apt-get update -y
+apt-get install gobgpd -y
 
 whoami
 printenv


### PR DESCRIPTION
Fixes (in `basic-setup.sh`):
- DNS resolving in some cases
- apt cache update before install
- install traceroute